### PR TITLE
Configurable Python Confidence Level

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -5,7 +5,9 @@ tsconfig.tsbuildinfo
 
 # Exclude test files and project directory
 src/test/
+test/
 
 # Exclude development/config files
 .vscode/
+.idea/
 launch.json

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ pip install vulture
 
 Run the `detect` command with paths to scan:
 ```bash
-deadcode-detective detect --js ./path/to/js --py ./path/to/python
+deadcode-detective detect --py ./src/test/python --confidence 70
 ```
 
 ### **Options**
@@ -74,6 +74,12 @@ If no dead code is found, you’ll see:
 ```bash
 ✅ No dead code found!
 ```
+---
+
+## Limitations
+
+For JavaScript projects without a tsconfig.json, Deadcode Detective provides limited detection using ts-prune. Use TypeScript or ES6 modules for full JavaScript support, or look for future updates with enhanced JS analysis.
+
 ---
 
 ## Try It Out

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deadcode-detective",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A tool to detect dead code in JavaScript/TypeScript and Python projects",
   "main": "dist/cli.js",
   "bin": {
@@ -30,11 +30,15 @@
   "dependencies": {
     "chalk": "^5.3.0",
     "commander": "^12.0.0",
+    "glob": "^11.0.1",
     "ora": "^8.0.1",
     "ts-prune": "^0.10.3"
   },
   "devDependencies": {
+    "@types/jest": "^29.5.14",
     "@types/node": "^22.7.5",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.2.6",
     "typescript": "^5.6.3"
   }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
+
 import { program } from 'commander';
 import chalk from 'chalk';
 import ora from 'ora';
-import { detectJS } from './detectors/js.js'; // Remove .ts
-import { detectPython } from './detectors/python.js'; // Remove .ts
+import { detectJS } from './detectors/js.js';
+import { detectPython } from './detectors/python.js';
 import { printResults, DeadCodeItem } from './utils.js';
 
 program
@@ -15,6 +16,7 @@ program
   .command('detect')
   .option('--js <path>', 'Scan JavaScript/TypeScript files')
   .option('--py <path>', 'Scan Python files')
+  .option('--confidence <number>', 'Confidence threshold for Python dead code detection (0-100, default: 60)', '60')
   .action(async (options) => {
     const spinner = ora('Scanning for dead code...').start();
     const results: { js?: DeadCodeItem[]; py?: DeadCodeItem[] } = {};
@@ -26,7 +28,8 @@ program
       }
       if (options.py) {
         spinner.text = 'Scanning Python files...';
-        results.py = await detectPython(options.py);
+        const confidence = parseInt(options.confidence, 10);
+        results.py = await detectPython(options.py, confidence);
       }
       spinner.succeed('Scan completed successfully');
       printResults(results);
@@ -36,5 +39,5 @@ program
       process.exit(1);
     }
   });
-
+  
 program.parse();

--- a/src/detectors/python.ts
+++ b/src/detectors/python.ts
@@ -1,17 +1,31 @@
 import { execSync } from 'child_process';
 import { DeadCodeItem } from '../utils';
 
-export async function detectPython(path: string): Promise<DeadCodeItem[]> {
+export async function detectPython(path: string, confidence?: number): Promise<DeadCodeItem[]> {
   console.log('Make sure `vulture` is installed (`pip install vulture`)');
   try {
-    const output = execSync(`vulture ${path} --min-confidence 60`, { encoding: 'utf-8' });
+    // Validate confidence
+    if (confidence !== undefined) {
+      if (isNaN(confidence)) {
+        throw new Error('Confidence must be a number between 0 and 100');
+      }
+      if (confidence > 100) {
+        throw new Error('Confidence cannot exceed 100');
+      }
+      if (confidence < 0) {
+        throw new Error('Confidence cannot be less than 0');
+      }
+    }
+
+    const minConfidence = Math.max(0, Math.min(100, confidence || 60));
+    const output = execSync(`vulture ${path} --min-confidence ${minConfidence}`, { encoding: 'utf-8' });
     return parseVultureOutput(output);
   } catch (error) {
     const err = error as any;
     if (err.stdout) {
       return parseVultureOutput(err.stdout.toString());
     }
-    return [];
+    throw new Error(err.stderr ? `vulture failed: ${err.stderr}` : `vulture error: ${err.message}`);
   }
 }
 
@@ -31,5 +45,5 @@ function parseVultureOutput(output: string): DeadCodeItem[] {
       return { file, symbol, type, line: parseInt(lineNumber) || 0 };
     })
     .filter((item): item is { file: string; symbol: string; type: string; line: number } => item !== null)
-    .map(item => ({ ...item } as DeadCodeItem)); // Cast to DeadCodeItem with optional `type`
-}
+    .map(item => ({ ...item } as DeadCodeItem)); 
+  }


### PR DESCRIPTION
**Summary**
This pull request introduces the ability to configure the confidence level for detecting dead code in Python files. The default confidence level is set to 60%, and error handling has been added to ensure the confidence value remains within a valid range (0-100).

**Key Changes**
Added a new configuration option to set the Python confidence level.

Implemented validation to restrict the confidence value between 0 and 100.

Ensured backward compatibility by keeping the default confidence level at 60%.

**Why This Change?**
This enhancement provides users with greater flexibility in tailoring the dead code detection process to their specific needs. By allowing the confidence level to be adjusted, users can fine-tune the balance between false positives and false negatives.