### PR TITLE
adds --ignore functionality to ignore files

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ deadcode-detective detect --py ./src/test/python --confidence 70
 - `--confidence <number>`: Confidence threshold for Python dead code detection (0-100, default: 60). Throws an error if above 100 or below 0.
 - `--format <type>`: Output format (cli, html, json, default: cli). Use html for web reports, json for machine-readable output, or cli for terminal output.
 - `--output <file>`: Output file path (for html or json, defaults to console for json, file 'deadcode-report.<format>' for html).
+- `--ignore <patterns>`: Comma-separated paths/patterns to ignore, **must** use single quotes and `**` wildcards (e.g., `'**/test/**,**/node_modules/**'`). Missing `**` or shell expansion (e.g., `C:/` in MINGW64) will fail the scan. In CMD, double quotes work (e.g., `"**/test/**"`). In MINGW64 (Git Bash), if expansion occurs, bypass the `node='winpty node.exe'` alias by running directly with the Node executable from its install location (e.g., `"C:\Path\To\Your\Nodejs\node.exe" dist/cli.js ..."`—replace with your Node.js path).
 
 ## Advance Usage with Formats
 
@@ -63,6 +64,13 @@ deadcode-detective detect --js ./src/test --py ./src/test/python --format html -
 # JSON report (machine-readable)
 deadcode-detective detect --js ./src/test --py ./src/test/python --format json --output report.json
 ```
+
+## Usage Tip
+
+### Running in MINGW64
+If `--ignore` patterns expand (e.g., `'**/test/**'` becomes `**C:/...`), the `node='winpty node.exe'` alias may interfere. Run directly with the Node executable:
+- Find your Node.js install path (e.g., `C:\Program Files\nodejs\` or wherever you installed it).
+- Use: `"C:\Path\To\Your\Nodejs\node.exe" dist/cli.js detect --py src/test/python --ignore '**/test/**,**/node_modules/**' --format cli`.
 
 ## Report Example Outputs
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ deadcode-detective detect --py ./src/test/python --confidence 70
 - `--output <file>`: Output file path (for html or json, defaults to console for json, file 'deadcode-report.<format>' for html).
 - `--ignore <patterns>`: Comma-separated paths/patterns to ignore, **must** use single quotes and `**` wildcards (e.g., `'**/test/**,**/node_modules/**'`). Missing `**` or shell expansion (e.g., `C:/` in MINGW64) will fail the scan. In CMD, double quotes work (e.g., `"**/test/**"`). In MINGW64 (Git Bash), if expansion occurs, bypass the `node='winpty node.exe'` alias by running directly with the Node executable from its install location (e.g., `"C:\Path\To\Your\Nodejs\node.exe" dist/cli.js ..."`—replace with your Node.js path).
 
+### Running in MINGW64
+If `--ignore` patterns expand (e.g., `'**/test/**'` becomes `**C:/...`), the `node='winpty node.exe'` alias may interfere. Run directly with the Node executable:
+- Find your Node.js install path (e.g., `C:\Program Files\nodejs\` or wherever you installed it).
+- Use: `"C:\Path\To\Your\Nodejs\node.exe" dist/cli.js detect --py src/test/python --ignore '**/test/**,**/node_modules/**' --format cli`.
+
 ## Advance Usage with Formats
 
 Generate rich, shareable reports using `--format` and `--output`:
@@ -64,13 +69,6 @@ deadcode-detective detect --js ./src/test --py ./src/test/python --format html -
 # JSON report (machine-readable)
 deadcode-detective detect --js ./src/test --py ./src/test/python --format json --output report.json
 ```
-
-## Usage Tip
-
-### Running in MINGW64
-If `--ignore` patterns expand (e.g., `'**/test/**'` becomes `**C:/...`), the `node='winpty node.exe'` alias may interfere. Run directly with the Node executable:
-- Find your Node.js install path (e.g., `C:\Program Files\nodejs\` or wherever you installed it).
-- Use: `"C:\Path\To\Your\Nodejs\node.exe" dist/cli.js detect --py src/test/python --ignore '**/test/**,**/node_modules/**' --format cli`.
 
 ## Report Example Outputs
 

--- a/package.json
+++ b/package.json
@@ -31,11 +31,13 @@
     "chalk": "^5.3.0",
     "commander": "^12.0.0",
     "glob": "^11.0.1",
+    "minimatch": "^10.0.1",
     "ora": "^8.0.1",
     "ts-prune": "^0.10.3"
   },
   "devDependencies": {
     "@types/jest": "^29.5.14",
+    "@types/minimatch": "^5.1.2",
     "@types/node": "^22.7.5",
     "jest": "^29.7.0",
     "ts-jest": "^29.2.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deadcode-detective",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "A tool to detect dead code in JavaScript/TypeScript and Python projects",
   "main": "dist/cli.js",
   "bin": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,6 +8,12 @@ import { detectPython } from './detectors/python.js';
 import { generateOutput } from './utils.js';
 import { DeadCodeItem } from './types.js';
 
+// Force UTF-8 on Windows
+if (process.platform === 'win32') {
+  process.stdout.setEncoding('utf8');
+  process.stderr.setEncoding('utf8');
+}
+
 program
   .name('deadcode-detective')
   .description('Detect dead code in JavaScript/TypeScript and Python projects')
@@ -18,21 +24,34 @@ program
   .option('--js <path>', 'Scan JavaScript/TypeScript files')
   .option('--py <path>', 'Scan Python files')
   .option('--confidence <number>', 'Confidence threshold for Python dead code detection (0-100, default: 60)', '60')
-  .option('--format <type>', 'Output format (cli, hyml, json, default: cli)', 'cli')
-  .option('--output <file>', 'Output file path (for html/json, defaults to console for json,file for html)')
+  .option('--format <type>', 'Output format (cli, html, json, default: cli)', 'cli')
+  .option('--output <file>', 'Output file path (for html/json, defaults to console for json, file for html)')
+  .option('--ignore <patterns>', 'Comma-separated paths/patterns to ignore (e.g., "**/test/**,node_modules/**")')
   .action(async (options) => {
     const spinner = ora('Scanning for dead code...').start();
     const results: { js?: DeadCodeItem[]; py?: DeadCodeItem[] } = {};
 
+    const rawPatterns = options.ignore ? options.ignore.split(',') : [];
+    console.log(`Raw ignore patterns: ${rawPatterns}`);
+    const hasExpansion = rawPatterns.some((p: string) => p.includes('C:') || p.match(/[A-Za-z]:/));
+    let ignorePatterns = rawPatterns
+      .map((p: string) => p.trim())
+      .filter((p: string) => !p.includes('C:') && !p.match(/[A-Za-z]:/));
+    console.log(`Filtered ignore patterns: ${ignorePatterns}`);
+    if (hasExpansion) {
+      console.warn(chalk.yellow('Warning: Shell expansion detected in ignore patterns. Ignoring them—use single quotes (e.g., \'**/test/**\') or check shell settings.'));
+      ignorePatterns = []; // No defaults, just skip bad patterns
+    }
+
     try {
       if (options.js) {
         spinner.text = 'Scanning JavaScript/TypeScript files...';
-        results.js = await detectJS(options.js);
+        results.js = await detectJS(options.js, ignorePatterns);
       }
       if (options.py) {
         spinner.text = 'Scanning Python files...';
         const confidence = parseInt(options.confidence, 10);
-        results.py = await detectPython(options.py, confidence);
+        results.py = await detectPython(options.py, confidence, ignorePatterns);
       }
       spinner.succeed('Scan completed successfully');
 
@@ -45,5 +64,5 @@ program
       process.exit(1);
     }
   });
-  
+
 program.parse();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -17,7 +17,7 @@ if (process.platform === 'win32') {
 program
   .name('deadcode-detective')
   .description('Detect dead code in JavaScript/TypeScript and Python projects')
-  .version('1.1.0');
+  .version('1.2.0');
 
 program
   .command('detect')

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -26,21 +26,34 @@ program
   .option('--confidence <number>', 'Confidence threshold for Python dead code detection (0-100, default: 60)', '60')
   .option('--format <type>', 'Output format (cli, html, json, default: cli)', 'cli')
   .option('--output <file>', 'Output file path (for html/json, defaults to console for json, file for html)')
-  .option('--ignore <patterns>', 'Comma-separated paths/patterns to ignore (e.g., "**/test/**,node_modules/**")')
+  .option('--ignore <patterns>', 'Comma-separated paths/patterns to ignore, must use single quotes and ** (e.g., \'**/test/**,**/node_modules/**\')')
   .action(async (options) => {
     const spinner = ora('Scanning for dead code...').start();
     const results: { js?: DeadCodeItem[]; py?: DeadCodeItem[] } = {};
 
-    const rawPatterns = options.ignore ? options.ignore.split(',') : [];
-    console.log(`Raw ignore patterns: ${rawPatterns}`);
-    const hasExpansion = rawPatterns.some((p: string) => p.includes('C:') || p.match(/[A-Za-z]:/));
-    let ignorePatterns = rawPatterns
-      .map((p: string) => p.trim())
-      .filter((p: string) => !p.includes('C:') && !p.match(/[A-Za-z]:/));
-    console.log(`Filtered ignore patterns: ${ignorePatterns}`);
-    if (hasExpansion) {
-      console.warn(chalk.yellow('Warning: Shell expansion detected in ignore patterns. Ignoring them—use single quotes (e.g., \'**/test/**\') or check shell settings.'));
-      ignorePatterns = []; // No defaults, just skip bad patterns
+    let ignorePatterns: string[] = [];
+    if (options.ignore) {
+      const rawPatterns = options.ignore.split(',');
+      console.log(`Raw ignore patterns: ${rawPatterns}`);
+
+      // Check for ** in every pattern
+      const missingWildcard = rawPatterns.some((p: string) => !p.includes('**'));
+      if (missingWildcard) {
+        spinner.fail('Invalid --ignore argument');
+        console.error(chalk.red('Error: All ignore patterns must contain "**" (e.g., \'**/test/**,**/node_modules/**\').'));
+        process.exit(1);
+      }
+
+      // Check for shell expansion
+      const hasExpansion = rawPatterns.some((p: string) => p.includes('C:') || p.match(/[A-Za-z]:/));
+      if (hasExpansion) {
+        spinner.fail('Invalid --ignore argument');
+        console.error(chalk.red('Error: Shell expansion detected. Use single quotes (e.g., \'**/test/**,**/node_modules/**\') and check shell settings (e.g., bypass winpty alias in MINGW64).'));
+        process.exit(1);
+      }
+
+      ignorePatterns = rawPatterns.map((p: string) => p.trim());
+      console.log(`Filtered ignore patterns: ${ignorePatterns}`);
     }
 
     try {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -33,14 +33,16 @@ program
 
     let ignorePatterns: string[] = [];
     if (options.ignore) {
-      const rawPatterns = options.ignore.split(',');
-      console.log(`Raw ignore patterns: ${rawPatterns}`);
+      // Strip leading/trailing quotes before splitting
+      const cleanedIgnore = options.ignore.replace(/^'|'$/g, '');
+      const rawPatterns = cleanedIgnore.split(',');
+      console.log(`\nRaw ignore patterns: ${rawPatterns}`);
 
       // Check for ** in every pattern
       const missingWildcard = rawPatterns.some((p: string) => !p.includes('**'));
       if (missingWildcard) {
         spinner.fail('Invalid --ignore argument');
-        console.error(chalk.red('Error: All ignore patterns must contain "**" (e.g., \'**/test/**,**/node_modules/**\').'));
+        console.error(chalk.red('Error: All ignore patterns must contain "**" (e.g., \'**/test/**,**/node_modules**\').'));
         process.exit(1);
       }
 
@@ -48,7 +50,7 @@ program
       const hasExpansion = rawPatterns.some((p: string) => p.includes('C:') || p.match(/[A-Za-z]:/));
       if (hasExpansion) {
         spinner.fail('Invalid --ignore argument');
-        console.error(chalk.red('Error: Shell expansion detected. Use single quotes (e.g., \'**/test/**,**/node_modules/**\') and check shell settings (e.g., bypass winpty alias in MINGW64).'));
+        console.error(chalk.red('Error: Shell expansion detected. Use single quotes (e.g., \'**/test/**,**/node_modules**\') and check shell settings (e.g., bypass winpty alias in MINGW64).'));
         process.exit(1);
       }
 
@@ -63,14 +65,13 @@ program
       }
       if (options.py) {
         spinner.text = 'Scanning Python files...';
-        const confidence = parseInt(options.confidence, 10);
-        results.py = await detectPython(options.py, confidence, ignorePatterns);
+        const confidence = parseInt(options.confidence, 10) || 60;
+        const confidenceValue = Math.max(0, Math.min(100, confidence));
+        results.py = await detectPython(options.py, confidenceValue, ignorePatterns);
       }
-      spinner.succeed('Scan completed successfully');
-
       const format = options.format.toLowerCase() as 'cli' | 'html' | 'json';
       const outputPath = options.output;
-      await generateOutput(results, format, outputPath);
+      await generateOutput(results, format, outputPath, spinner);
     } catch (error) {
       spinner.fail('Scan failed');
       console.error(chalk.red(error instanceof Error ? error.message : String(error)));

--- a/src/detectors/js.ts
+++ b/src/detectors/js.ts
@@ -3,7 +3,7 @@ import { resolve } from 'path';
 import { existsSync } from 'fs';
 import { DeadCodeItem } from '../types.js';
 
-export async function detectJS(path: string): Promise<DeadCodeItem[]> {
+export async function detectJS(path: string, _ignorePatterns: string[]): Promise<DeadCodeItem[]> {
   console.log('Make sure `ts-prune` is installed (`npm install -g ts-prune`)');
   try {
     const tsConfigPath = './tsconfig.json';

--- a/src/detectors/python.ts
+++ b/src/detectors/python.ts
@@ -1,25 +1,27 @@
 import { execSync } from 'child_process';
+import { existsSync, readdirSync, Dirent } from 'fs';
+import { join, resolve, relative } from 'path';
+import { minimatch } from 'minimatch';
 import { DeadCodeItem } from '../types.js';
 import chalk from 'chalk';
 
-export async function detectPython(path: string, confidence?: number): Promise<DeadCodeItem[]> {
+export async function detectPython(path: string, confidence: number = 60, ignorePatterns: string[] = []): Promise<DeadCodeItem[]> {
   console.log('Make sure `vulture` is installed (`pip install vulture`)');
   try {
-    // Validate confidence
-    if (confidence !== undefined) {
-      if (isNaN(confidence)) {
-        throw new Error('Confidence must be a number between 0 and 100');
-      }
-      if (confidence > 100) {
-        throw new Error('Confidence cannot exceed 100');
-      }
-      if (confidence < 0) {
-        throw new Error('Confidence cannot be less than 0');
-      }
+    if (isNaN(confidence) || confidence > 100 || confidence < 0) {
+      throw new Error('Confidence must be a number between 0 and 100');
     }
 
-    const minConfidence = Math.max(0, Math.min(100, confidence || 60));
-    const output = execSync(`vulture ${path} --min-confidence ${minConfidence}`, { encoding: 'utf-8' });
+    const minConfidence = Math.max(0, Math.min(100, confidence));
+    const projectRoot = resolve(process.cwd());
+    const files = getFiles(path).filter(file => {
+      const absoluteFile = resolve(file).replace(/\\/g, '/');
+      const relativeFile = relative(projectRoot, absoluteFile).replace(/\\/g, '/');
+      return !ignorePatterns.some(pattern => minimatch(relativeFile, pattern.replace(/\\/g, '/'), { matchBase: false, dot: true }));
+    });
+    if (files.length === 0) return [];
+
+    const output = execSync(`vulture ${files.join(' ')} --min-confidence ${minConfidence}`, { encoding: 'utf-8' });
     return parseVultureOutput(output);
   } catch (error) {
     const err = error as any;
@@ -29,6 +31,21 @@ export async function detectPython(path: string, confidence?: number): Promise<D
     console.error(chalk.red('vulture error occurred, returning empty results:', err.message || err.stderr));
     return [];
   }
+}
+
+function getFiles(dir: string): string[] {
+  const results: string[] = [];
+  if (!existsSync(dir)) return results;
+  const entries: Dirent[] = readdirSync(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...getFiles(fullPath));
+    } else if (fullPath.endsWith('.py')) {
+      results.push(fullPath);
+    }
+  }
+  return results;
 }
 
 function parseVultureOutput(output: string): DeadCodeItem[] {
@@ -48,9 +65,9 @@ function parseVultureOutput(output: string): DeadCodeItem[] {
       return {
         file,
         symbol,
-        type, 
+        type,
         line: parseInt(lineNumber) || 0,
-        confidence, 
+        confidence,
       } as DeadCodeItem;
     })
     .filter((item): item is DeadCodeItem => item !== null);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,10 +1,11 @@
 import chalk from 'chalk';
+import { Ora } from 'ora';
 import { generateHtmlOutput } from './output/html.js';
 import { generateJsonOutput } from './output/json.js';
 import { DeadCodeItem } from './types.js';
 
 function printCliResults(results: { js?: DeadCodeItem[]; py?: DeadCodeItem[] }) {
-  console.log(chalk.bold('\n\u{1F50E} Dead Code Report:')); // 🔎 as Unicode escape
+  console.log(chalk.bold('\n\u{1F50E} Dead Code Report:'));
 
   if (results.js?.length) {
     console.log(chalk.red(`\n❗ Found ${results.js.length} unused item${results.js.length > 1 ? 's' : ''} in JavaScript/TypeScript:`));
@@ -35,27 +36,36 @@ export function groupAndSortByFile(items: DeadCodeItem[]): { [file: string]: Dea
     grouped[item.file] = grouped[item.file] || [];
     grouped[item.file].push(item);
   });
-  // Sort files alphabetically and items within each file by line number
   for (const file in grouped) {
     grouped[file].sort((a, b) => a.line - b.line);
   }
   return grouped;
 }
 
-export async function generateOutput(results: { js?: DeadCodeItem[]; py?: DeadCodeItem[] }, format: 'cli' | 'html' | 'json', outputPath?: string) {
+export async function generateOutput(
+  results: { js?: DeadCodeItem[]; py?: DeadCodeItem[] },
+  format: 'cli' | 'html' | 'json',
+  outputPath?: string,
+  spinner?: Ora
+) {
   switch (format) {
     case 'cli':
+      if (spinner) spinner.succeed('Scan completed successfully');
       printCliResults(results);
       break;
 
     case 'html':
+      if (spinner) spinner.succeed('Scan completed successfully');
       await generateHtmlOutput(results, outputPath);
       break;
 
     case 'json':
+      if (spinner) spinner.succeed('Scan completed successfully');
       await generateJsonOutput(results, outputPath);
       break;
+
     default:
+      if (spinner) spinner.fail('Invalid format');
       throw new Error('Invalid Format');
   }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,7 +4,7 @@ import { generateJsonOutput } from './output/json.js';
 import { DeadCodeItem } from './types.js';
 
 function printCliResults(results: { js?: DeadCodeItem[]; py?: DeadCodeItem[] }) {
-  console.log(chalk.bold('\n🔎 Dead Code Report:'));
+  console.log(chalk.bold('\n\u{1F50E} Dead Code Report:')); // 🔎 as Unicode escape
 
   if (results.js?.length) {
     console.log(chalk.red(`\n❗ Found ${results.js.length} unused item${results.js.length > 1 ? 's' : ''} in JavaScript/TypeScript:`));


### PR DESCRIPTION
## Description
This PR introduces the `--ignore` feature, allowing users to specify paths that should be skipped during dead code detection by **deadcode-detective**.  

- Added the `--ignore` flag to exclude user-specified paths from analysis.  
- Implemented error handling for path expansion issues that occur when using **Git Bash**.  
- This is an interim solution—once a configuration file is introduced, path handling will be managed more effectively.  

## Future Considerations  
- The config file implementation will provide a more robust way to handle ignored paths, eliminating the need for manual flag input.  

## Type of Change

- [x] New feature

## Checklist

- [x] My code follows the project's coding style and guidelines.
- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have updated the documentation as needed.

## Additional Information

![image](https://github.com/user-attachments/assets/4f6d710a-cff1-4b46-80cf-eb8a8146c7d9)
![image](https://github.com/user-attachments/assets/9a09fab9-3638-409d-9167-4fd8c4cfd321)
![image](https://github.com/user-attachments/assets/4f393477-398a-4f59-8481-875ac48d4a1b)
